### PR TITLE
Including globals file in package.json globals declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "main": "index.js",
   "files": [
     "index.js",
+    "globals.js",
     "mock/"
   ],
   "scripts": {


### PR DESCRIPTION
This will fix issue #2, as the `globals.js` file was not being included in the final published module.